### PR TITLE
Fixed typo in gcloud CLI: 'python', not 'pypi'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the keyring backend:
 
 2. Configure twine (`.pypirc`) and pip (`pip.conf`) tools to connect to the repository. Use the output from the following command:
 
-        $ gcloud alpha artifacts print-settings pypi
+        $ gcloud alpha artifacts print-settings python
 
     In your `.pypirc` file add:
 


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/artifact-registry-python-tools/issues/19