### PR TITLE
Use service as hostname fallback to enable keyring usage on redirects

### DIFF
--- a/keyrings/gauth.py
+++ b/keyrings/gauth.py
@@ -37,7 +37,9 @@ class GooglePythonAuth(backend.KeyringBackend):
 
   def get_password(self,service,username):
     url = urlparse(service)
-    if url.hostname is None or not url.hostname.endswith(".pkg.dev"):
+    hostname = service if url.hostname is None else url.hostname
+
+    if hostname is None or not hostname.endswith(".pkg.dev"):
       return
 
     #trying application default credentials otherwise fall back to gcloud credentials command


### PR DESCRIPTION
### Description

When following redirects that don't point to one of the configured indexes `pip` will request credentials from the keyrings using the `netloc` taken from the new location's url ([ref](https://github.com/pypa/pip/blob/main/src/pip/_internal/network/auth.py#L156)).

The current implementation relies on `urlib.urlparse` to determine `hostname` (which is part of `netloc`). `urlparse` requires a url to have a schema (or at least `//`) in order to detect a `netloc` ([ref](https://docs.python.org/3.7/library/urllib.parse.html?highlight=urlparse#url-parsing)), which makes it misclassify a previously parsed `netloc` as a `path`.

I proposed falling back to using the `service` as is when a `hostname` cannot be found (ex. when `service` is just a url's `netloc`).

### Motivation

Using a private pypi server that redirects to a GCP Artifact Registry Python repository for certain dependencies.