### PR TITLE
Update keyring import.

### DIFF
--- a/keyrings/gauth.py
+++ b/keyrings/gauth.py
@@ -21,7 +21,7 @@ from google.auth.exceptions import DefaultCredentialsError
 import keyring
 from keyring import backend
 from keyring import credentials
-from keyring.util import properties
+from keyring._compat import properties
 from urllib.parse import urlparse
 
 import json


### PR DESCRIPTION
keyring 23.9.0 deleted the util file and renamed it _compat. Updating the import to be compatible with keyring 23.9.0

https://github.com/jaraco/keyring/pull/588/files contains the changes that were part of the new release. 